### PR TITLE
add dropCache method

### DIFF
--- a/src/core/manager.js
+++ b/src/core/manager.js
@@ -12,6 +12,14 @@ export const dropByCacheKey = key => {
   })
 }
 
+export const dropCache = () => {
+  Object.entries(__components)
+    .filter(([, component]) => component.state.cached)
+    .forEach(([key]) => run(__components, [key, 'setState'], {
+      cached: false
+    }))
+}
+
 export const getCachingKeys = () =>
   Object.entries(__components)
     .filter(([, component]) => component.state.cached)


### PR DESCRIPTION
invalidate the whole cache with one command.
this can be useful if you need to invalidate the entire cache when you change certain routes.
think about a main menu and a sub menu: when the use navigates the sub menu, all the sub routes are cached and fetched from the cache. then, when the user navigates the main menu, all the cached routes need to be dropped.