### PR TITLE
fix: wrapper CacheSwitch with div to avoid error in React v16 -

### DIFF
--- a/src/components/CacheSwitch.js
+++ b/src/components/CacheSwitch.js
@@ -4,6 +4,7 @@ import { Switch, matchPath } from 'react-router-dom'
 
 import { isNull } from '../helpers/is'
 import { get } from '../helpers/try'
+import { isReactV16plus } from '../helpers/util'
 
 export default class CacheSwitch extends Switch {
   static contextTypes = {
@@ -24,61 +25,64 @@ export default class CacheSwitch extends Switch {
 
     let __matched__already = false
 
-    return (
-      <div>
-        {
-          React.Children.map(children, element => {
-            if (!React.isValidElement(element)) {
-              return null
-            }
 
-            const { path: pathProp, exact, strict, sensitive, from } = element.props
-            const path = pathProp || from
-            const match = __matched__already
-              ? null
-              : matchPath(
-                location.pathname,
-                { path, exact, strict, sensitive },
-                route.match
-              )
 
-            let child
-            switch (get(element, 'type.componentName')) {
-              case 'CacheRoute':
-                child = React.cloneElement(element, {
-                  location,
-                  /**
-                   * https://github.com/ReactTraining/react-router/blob/master/packages/react-router/modules/Route.js#L57
-                   *
-                   * Note:
-                   * Route would use computedMatch as its next match state ONLY when computedMatch is a true value
-                   * So here we have to do some trick to let the unmatch result pass Route's computedMatch check
-                   *
-                   * 注意：只有当 computedMatch 为真值时，Route 才会使用 computedMatch 作为其下一个匹配状态
-                   * 所以这里我们必须做一些手脚，让 unmatch 结果通过 Route 的 computedMatch 检查
-                   */
-                  computedMatch: isNull(match)
-                    ? {
-                      __CacheRoute__computedMatch__null: true
-                    }
-                    : match
-                })
-                break
-              default:
-                child =
-                  match && !__matched__already
-                    ? React.cloneElement(element, { location, computedMatch: match })
-                    : null
-            }
+    let component = React.Children.map(children, element => {
+      if (!React.isValidElement(element)) {
+        return null
+      }
 
-            if (!__matched__already) {
-              __matched__already = !!match
-            }
+      const { path: pathProp, exact, strict, sensitive, from } = element.props
+      const path = pathProp || from
+      const match = __matched__already
+        ? null
+        : matchPath(
+          location.pathname,
+          { path, exact, strict, sensitive },
+          route.match
+        )
 
-            return child
+      let child
+      switch (get(element, 'type.componentName')) {
+        case 'CacheRoute':
+          child = React.cloneElement(element, {
+            location,
+            /**
+             * https://github.com/ReactTraining/react-router/blob/master/packages/react-router/modules/Route.js#L57
+             *
+             * Note:
+             * Route would use computedMatch as its next match state ONLY when computedMatch is a true value
+             * So here we have to do some trick to let the unmatch result pass Route's computedMatch check
+             *
+             * 注意：只有当 computedMatch 为真值时，Route 才会使用 computedMatch 作为其下一个匹配状态
+             * 所以这里我们必须做一些手脚，让 unmatch 结果通过 Route 的 computedMatch 检查
+             */
+            computedMatch: isNull(match)
+              ? {
+                __CacheRoute__computedMatch__null: true
+              }
+              : match
           })
-        }
-      </div>
-    )
+          break
+        default:
+          child =
+            match && !__matched__already
+              ? React.cloneElement(element, { location, computedMatch: match })
+              : null
+      }
+
+      if (!__matched__already) {
+        __matched__already = !!match
+      }
+
+      return child
+    })
+
+    if (!isReactV16plus) {
+      component = <div>{component}</div>
+    }
+
+    return component;
+
   }
 }

--- a/src/components/CacheSwitch.js
+++ b/src/components/CacheSwitch.js
@@ -24,55 +24,61 @@ export default class CacheSwitch extends Switch {
 
     let __matched__already = false
 
-    return React.Children.map(children, element => {
-      if (!React.isValidElement(element)) {
-        return null
-      }
+    return (
+      <div>
+        {
+          React.Children.map(children, element => {
+            if (!React.isValidElement(element)) {
+              return null
+            }
 
-      const { path: pathProp, exact, strict, sensitive, from } = element.props
-      const path = pathProp || from
-      const match = __matched__already
-        ? null
-        : matchPath(
-            location.pathname,
-            { path, exact, strict, sensitive },
-            route.match
-          )
+            const { path: pathProp, exact, strict, sensitive, from } = element.props
+            const path = pathProp || from
+            const match = __matched__already
+              ? null
+              : matchPath(
+                location.pathname,
+                { path, exact, strict, sensitive },
+                route.match
+              )
 
-      let child
-      switch (get(element, 'type.componentName')) {
-        case 'CacheRoute':
-          child = React.cloneElement(element, {
-            location,
-            /**
-             * https://github.com/ReactTraining/react-router/blob/master/packages/react-router/modules/Route.js#L57
-             *
-             * Note:
-             * Route would use computedMatch as its next match state ONLY when computedMatch is a true value
-             * So here we have to do some trick to let the unmatch result pass Route's computedMatch check
-             *
-             * 注意：只有当 computedMatch 为真值时，Route 才会使用 computedMatch 作为其下一个匹配状态
-             * 所以这里我们必须做一些手脚，让 unmatch 结果通过 Route 的 computedMatch 检查
-             */
-            computedMatch: isNull(match)
-              ? {
-                  __CacheRoute__computedMatch__null: true
-                }
-              : match
+            let child
+            switch (get(element, 'type.componentName')) {
+              case 'CacheRoute':
+                child = React.cloneElement(element, {
+                  location,
+                  /**
+                   * https://github.com/ReactTraining/react-router/blob/master/packages/react-router/modules/Route.js#L57
+                   *
+                   * Note:
+                   * Route would use computedMatch as its next match state ONLY when computedMatch is a true value
+                   * So here we have to do some trick to let the unmatch result pass Route's computedMatch check
+                   *
+                   * 注意：只有当 computedMatch 为真值时，Route 才会使用 computedMatch 作为其下一个匹配状态
+                   * 所以这里我们必须做一些手脚，让 unmatch 结果通过 Route 的 computedMatch 检查
+                   */
+                  computedMatch: isNull(match)
+                    ? {
+                      __CacheRoute__computedMatch__null: true
+                    }
+                    : match
+                })
+                break
+              default:
+                child =
+                  match && !__matched__already
+                    ? React.cloneElement(element, { location, computedMatch: match })
+                    : null
+            }
+
+            if (!__matched__already) {
+              __matched__already = !!match
+            }
+
+            return child
           })
-          break
-        default:
-          child =
-            match && !__matched__already
-              ? React.cloneElement(element, { location, computedMatch: match })
-              : null
-      }
-
-      if (!__matched__already) {
-        __matched__already = !!match
-      }
-
-      return child
-    })
+        }
+      </div>
+    )
   }
 }

--- a/src/helpers/util.js
+++ b/src/helpers/util.js
@@ -1,0 +1,2 @@
+import React from 'react'
+export const isReactV16plus = !!!React.PropTypes


### PR DESCRIPTION
resolve #19 
Because React Components can return array since React v16, to avoid error when using `CacheSwitch` Component in React v16 - , need to handle the return array.