### PR TITLE
feat: add refreshByCacheKey method to support refreshing a route by key

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,6 +23,7 @@ export interface CacheSwitchProps extends SwitchProps {
 export declare class CacheSwitch extends React.Component<CacheSwitchProps> {}
 
 export function dropByCacheKey(cacheKey: string): void
+export function refreshByCacheKey(cacheKey: string): void
 export function getCachingKeys(): Array<string>
 export function clearCache(): void
 

--- a/src/core/CacheComponent.js
+++ b/src/core/CacheComponent.js
@@ -138,7 +138,8 @@ export default class CacheComponent extends Component {
 
     this.state = getDerivedStateFromProps(props, {
       cached: false,
-      matched: false
+      matched: false,
+      key: Math.random()
     })
   }
 
@@ -282,8 +283,16 @@ export default class CacheComponent extends Component {
     })
   }
 
+  refresh = () => {
+    delete this.__revertScrollPos;
+
+    this.setState({
+      key: Math.random()
+    });
+  };
+
   render() {
-    const { matched, cached } = this.state
+    const { matched, cached, key } = this.state
     const { className: propsClassName = '', behavior, children } = this.props
     const { className: behaviorClassName = '', ...behaviorProps } = value(
       run(behavior, undefined, !matched),
@@ -294,6 +303,7 @@ export default class CacheComponent extends Component {
 
     return cached ? (
       <div
+        key={key}
         className={hasClassName ? className : undefined}
         {...behaviorProps}
         ref={wrapper => {

--- a/src/core/manager.js
+++ b/src/core/manager.js
@@ -37,6 +37,22 @@ export const dropByCacheKey = key => {
   }
 }
 
+const refreshComponent = component => run(component, 'refresh');
+
+export const refreshByCacheKey = key => {
+  const cache = get(__components, [key]);
+
+  if (!cache) {
+    return;
+  }
+
+  if (cache instanceof CacheComponent) {
+    refreshComponent(cache);
+  } else {
+    Object.values(cache).forEach(refreshComponent);
+  }
+};
+
 export const clearCache = () => {
   getCachedComponentEntries().forEach(([key]) => dropByCacheKey(key))
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ export CacheRoute from './components/CacheRoute'
 export CacheSwitch from './components/CacheSwitch'
 export {
   dropByCacheKey,
+  refreshByCacheKey,
   getCachingKeys,
   clearCache,
   getCachingComponents


### PR DESCRIPTION
```js
import CacheRoute, { refreshByCacheKey } from 'react-router-cache-route'

...
<CacheRoute ... cacheKey="MyComponent" />
...

refreshByCacheKey('MyComponent') // to refresh
...
```