### PR TITLE
Promise方式重构manager内的dropByCacheKey等方法

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,10 +22,10 @@ export interface CacheSwitchProps extends SwitchProps {
 
 export declare class CacheSwitch extends React.Component<CacheSwitchProps> {}
 
-export function dropByCacheKey(cacheKey: string): void
-export function refreshByCacheKey(cacheKey: string): void
+export function dropByCacheKey(cacheKey: string): Promise
+export function refreshByCacheKey(cacheKey: string): Promise
 export function getCachingKeys(): Array<string>
-export function clearCache(): void
+export function clearCache(): Promise
 
 export interface CachingComponent extends React.ComponentClass {
   __cacheCreateTime: number

--- a/src/core/CacheComponent.js
+++ b/src/core/CacheComponent.js
@@ -294,18 +294,21 @@ export default class CacheComponent extends Component {
     }
   }
 
+  setStateAsync(state) {
+    return new Promise((resolve) => {
+      this.setState(state, resolve)
+    });
+  }
   reset = () => {
     delete this.__revertScrollPos
-
-    this.setState({
+    return this.setStateAsync({
       cached: false
     })
   }
 
   refresh = () => {
     delete this.__revertScrollPos;
-
-    this.setState({
+    return this.setStateAsync({
       key: Math.random()
     });
   };

--- a/src/core/manager.js
+++ b/src/core/manager.js
@@ -21,17 +21,16 @@ export const remove = key => {
   delete __components[key]
 }
 
-const dropComponent = component => run(component, 'reset')
+const dropComponent = (component) => run(component, 'reset')
 
-export const dropByCacheKey = (key, callBack) => {
+export const dropByCacheKey = (key) => {
   const cache = get(__components, [key])
-
   if (!cache) {
     return
   }
 
   if (cache instanceof CacheComponent) {
-    return dropComponent(cache, callBack)
+    return dropComponent(cache)
   } else {
     return Promise.all(Object.values(cache).forEach(dropComponent))
   }

--- a/src/core/manager.js
+++ b/src/core/manager.js
@@ -21,9 +21,9 @@ export const remove = key => {
   delete __components[key]
 }
 
-const dropComponent = (component) => run(component, 'reset')
+const dropComponent = component => run(component, 'reset')
 
-export const dropByCacheKey = (key) => {
+export const dropByCacheKey = key => {
   const cache = get(__components, [key])
   if (!cache) {
     return

--- a/src/core/manager.js
+++ b/src/core/manager.js
@@ -23,7 +23,7 @@ export const remove = key => {
 
 const dropComponent = component => run(component, 'reset')
 
-export const dropByCacheKey = key => {
+export const dropByCacheKey = (key, callBack) => {
   const cache = get(__components, [key])
 
   if (!cache) {
@@ -31,9 +31,9 @@ export const dropByCacheKey = key => {
   }
 
   if (cache instanceof CacheComponent) {
-    dropComponent(cache)
+    return dropComponent(cache, callBack)
   } else {
-    Object.values(cache).forEach(dropComponent)
+    return Promise.all(Object.values(cache).forEach(dropComponent))
   }
 }
 
@@ -47,14 +47,14 @@ export const refreshByCacheKey = key => {
   }
 
   if (cache instanceof CacheComponent) {
-    refreshComponent(cache);
+    return refreshComponent(cache);
   } else {
-    Object.values(cache).forEach(refreshComponent);
+    return Promise.all(Object.values(cache).map(refreshComponent));
   }
 };
 
 export const clearCache = () => {
-  getCachedComponentEntries().forEach(([key]) => dropByCacheKey(key))
+  return Promise.all(getCachedComponentEntries().map(([key]) => dropByCacheKey(key)))
 }
 
 export const getCachingKeys = () =>


### PR DESCRIPTION
主要为了能够在使用中实现类似     调用跳转方法 -> 判断是否需要清除缓存 -> 清除缓存 -> 跳转  这样的业务需求 