### PR TITLE
defaultProps deprecated

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,6 @@
 docs
 node_modules
-src
+# src
 .babelrc
 .gitignore
 .npmignore

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 'use strict';
 
-if (process.env.NODE_ENV === 'production') {
-  module.exports = require('./lib/index.min.js');
-} else {
-  module.exports = require('./lib/index.js');
-}
+// if (process.env.NODE_ENV === 'production') {
+//   module.exports = require('./lib/index.min.js');
+// } else {
+//   module.exports = require('./lib/index.js');
+// }
+module.exports = require('./src/index.js');

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-router-cache-route",
   "version": "1.13.0",
   "description": "cache-route for react-router base on react v15+ and router v4+",
-  "main": "index.js",
+  "main": "src/index.js",
   "scripts": {
     "build": "rollup --config"
   },

--- a/src/components/CacheSwitch.js
+++ b/src/components/CacheSwitch.js
@@ -33,7 +33,11 @@ class CacheSwitch extends Switch {
   }
 
   render() {
-    const { children, which, autoFreeze } = this.props
+    const {
+      children,
+      which = element => get(element, 'type.__name') === 'CacheRoute',
+      autoFreeze
+    } = this.props
     const { location, match: contextMatch } = this.getContext()
 
     let __matchedAlready = false
@@ -129,10 +133,6 @@ if (isUsingNewContext) {
     location: PropTypes.object,
     which: PropTypes.func
   }
-}
-
-CacheSwitch.defaultProps = {
-  which: element => get(element, 'type.__name') === 'CacheRoute'
 }
 
 export default CacheSwitch


### PR DESCRIPTION
Remove deprecated defaultProps construct for CacheSwitch component. Instead move it to render function in spread default values.